### PR TITLE
Update cross to use edge images in some cases

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-freebsd]
+image = "ghcr.io/cross-rs/x86_64-unknown-freebsd:edge"
+
+[target.i686-unknown-freebsd]
+image = "ghcr.io/cross-rs/i686-unknown-freebsd:edge"

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,6 @@ image = "ghcr.io/cross-rs/x86_64-unknown-freebsd:edge"
 
 [target.i686-unknown-freebsd]
 image = "ghcr.io/cross-rs/i686-unknown-freebsd:edge"
+
+[target.x86_64-sun-solaris]
+image = "ghcr.io/cross-rs/x86_64-sun-solaris:edge"

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,6 +3,3 @@ image = "ghcr.io/cross-rs/x86_64-unknown-freebsd:edge"
 
 [target.i686-unknown-freebsd]
 image = "ghcr.io/cross-rs/i686-unknown-freebsd:edge"
-
-[target.x86_64-sun-solaris]
-image = "ghcr.io/cross-rs/x86_64-sun-solaris:edge"

--- a/crates.json
+++ b/crates.json
@@ -2,7 +2,7 @@
   "crates": {
     "bacon": {
       "flags": "",
-      "unsupported": "x86_64-unknown-freebsd,x86_64-unknown-netbsd,x86_64-sun-solaris,i686-unknown-freebsd",
+      "unsupported": "",
       "git": "https://github.com/Canop/bacon",
       "bins": [
         "bacon"
@@ -313,5 +313,5 @@
       ]
     }
   },
-  "allowlist": "cargo-generate,just,cargo-prebuilt,cargo-deb,cargo-asm,cargo-hack,cargo-nextest"
+  "allowlist": "bacon"
 }

--- a/crates.json
+++ b/crates.json
@@ -86,7 +86,7 @@
 
     "tauri-cli": {
       "flags": "",
-      "unsupported": "",
+      "unsupported": "x86_64-unknown-freebsd,x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
       "git": "https://github.com/tauri-apps/tauri",
       "bins": [
         "cargo-tauri"
@@ -251,7 +251,7 @@
 
     "cargo-watch": {
       "flags": "",
-      "unsupported": "",
+      "unsupported": "x86_64-unknown-illumos,x86_64-sun-solaris",
       "git": "https://github.com/watchexec/cargo-watch",
       "bins": [
         "cargo-watch"
@@ -313,5 +313,5 @@
       ]
     }
   },
-  "allowlist": "cargo-watch"
+  "allowlist": "tauri-cli,cargo-watch"
 }

--- a/crates.json
+++ b/crates.json
@@ -270,7 +270,7 @@
 
     "sccache": {
       "flags": "--features openssl/vendored",
-      "unsupported": "x86_64-unknown-freebsd,x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
+      "unsupported": "",
       "git": "https://github.com/mozilla/sccache",
       "bins": [
         "sccache"
@@ -313,5 +313,5 @@
       ]
     }
   },
-  "allowlist": "tauri-cli,cargo-watch"
+  "allowlist": "sccache"
 }

--- a/crates.json
+++ b/crates.json
@@ -313,5 +313,5 @@
       ]
     }
   },
-  "allowlist": "tauri-cli"
+  "allowlist": "cargo-watch"
 }

--- a/crates.json
+++ b/crates.json
@@ -251,7 +251,7 @@
 
     "cargo-watch": {
       "flags": "",
-      "unsupported": "x86_64-unknown-freebsd,x86_64-unknown-illumos,x86_64-sun-solaris,i686-unknown-freebsd",
+      "unsupported": "",
       "git": "https://github.com/watchexec/cargo-watch",
       "bins": [
         "cargo-watch"

--- a/crates.json
+++ b/crates.json
@@ -2,7 +2,7 @@
   "crates": {
     "bacon": {
       "flags": "",
-      "unsupported": "",
+      "unsupported": "x86_64-sun-solaris",
       "git": "https://github.com/Canop/bacon",
       "bins": [
         "bacon"
@@ -86,7 +86,7 @@
 
     "tauri-cli": {
       "flags": "",
-      "unsupported": "x86_64-unknown-freebsd,x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
+      "unsupported": "",
       "git": "https://github.com/tauri-apps/tauri",
       "bins": [
         "cargo-tauri"
@@ -313,5 +313,5 @@
       ]
     }
   },
-  "allowlist": "bacon"
+  "allowlist": "tauri-cli"
 }

--- a/crates.json
+++ b/crates.json
@@ -270,7 +270,7 @@
 
     "sccache": {
       "flags": "--features openssl/vendored",
-      "unsupported": "",
+      "unsupported": "x86_64-unknown-freebsd,x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
       "git": "https://github.com/mozilla/sccache",
       "bins": [
         "sccache"

--- a/crates.json
+++ b/crates.json
@@ -41,7 +41,7 @@
 
     "cargo-generate": {
       "flags": "--features vendored-openssl",
-      "unsupported": "x86_64-unknown-freebsd,i686-unknown-freebsd",
+      "unsupported": "",
       "git": "https://github.com/cargo-generate/cargo-generate",
       "bins": [
         "cargo-generate"
@@ -68,7 +68,7 @@
 
     "just": {
       "flags": "",
-      "unsupported": "x86_64-unknown-freebsd,i686-unknown-freebsd",
+      "unsupported": "",
       "git": "https://github.com/casey/just",
       "bins": [
         "just"
@@ -104,7 +104,7 @@
 
     "cargo-prebuilt": {
       "flags": "",
-      "unsupported": "x86_64-unknown-freebsd,i686-unknown-freebsd",
+      "unsupported": "",
       "git": "https://github.com/crow-rest/cargo-prebuilt",
       "bins": [
         "cargo-prebuilt"
@@ -132,7 +132,7 @@
 
     "cargo-deb": {
       "flags": "",
-      "unsupported": "x86_64-unknown-freebsd,x86_64-sun-solaris,i686-unknown-freebsd",
+      "unsupported": "x86_64-sun-solaris",
       "git": "https://github.com/kornelski/cargo-deb",
       "bins": [
         "cargo-deb"
@@ -177,7 +177,7 @@
 
     "cargo-asm": {
       "flags": "",
-      "unsupported": "x86_64-unknown-freebsd,i686-unknown-freebsd",
+      "unsupported": "",
       "git": "https://github.com/gnzlbg/cargo-asm",
       "bins": [
         "cargo-asm",
@@ -279,7 +279,7 @@
 
     "cargo-hack": {
       "flags": "",
-      "unsupported": "x86_64-unknown-freebsd,i686-unknown-freebsd",
+      "unsupported": "",
       "git": "https://github.com/taiki-e/cargo-hack",
       "bins": [
         "cargo-hack"
@@ -288,7 +288,7 @@
 
     "cargo-nextest": {
       "flags": "--no-default-features --features default-no-update",
-      "unsupported": "x86_64-unknown-freebsd,x86_64-sun-solaris,i686-unknown-freebsd",
+      "unsupported": "x86_64-sun-solaris",
       "git": "https://github.com/nextest-rs/nextest",
       "bins": [
         "cargo-nextest"
@@ -313,5 +313,5 @@
       ]
     }
   },
-  "allowlist": "just"
+  "allowlist": "cargo-generate,just,cargo-prebuilt,cargo-deb,cargo-asm,cargo-hack,cargo-nextest"
 }


### PR DESCRIPTION
Closes #44 

Fixes Crates (Freebsd):
- [x] cargo-generate
- [x] just
- [x] cargo-prebuilt
- [x] cargo-deb
- [x] cargo-asm
- [x] cargo-hack
- [x] cargo-nextest
- [x] bacon?
- [x] cargo-watch?
- [x] ~tauri-cli?~
- [x] ~sccache?~