### PR TITLE
Add gitoxide, du-dust, bat, ripgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Prebuilt crates optionally support these targets:
 ## Crates
 
 - [bacon](https://github.com/Canop/bacon)
+- [bat](https://github.com/sharkdp/bat)
 - [cargo-asm](https://github.com/gnzlbg/cargo-asm)
 - [cargo-audit](https://github.com/rustsec/rustsec/tree/main/cargo-audit)
 - [cargo-auditable](https://github.com/rust-secure-code/cargo-auditable)
@@ -79,9 +80,12 @@ Prebuilt crates optionally support these targets:
 - [cargo-watch](https://github.com/watchexec/cargo-watch)
 - [cocogitto](https://github.com/cocogitto/cocogitto)
 - [cross](https://github.com/cross-rs/cross)
+- [du-dust](https://github.com/bootandy/dust)
+- [gitoxide](https://github.com/Byron/gitoxide)
 - [grcov](https://github.com/mozilla/grcov)
 - [jql](https://github.com/yamafaktory/jql)
 - [just](https://github.com/casey/just)
+- [ripgrep](https://github.com/BurntSushi/ripgrep)
 - [sccache](https://github.com/mozilla/sccache)
 - [tauri-cli](https://github.com/tauri-apps/tauri)
 - [trunk](https://github.com/thedodd/trunk)

--- a/crates.json
+++ b/crates.json
@@ -339,7 +339,53 @@
         "cross",
         "cross-util"
       ]
+    },
+
+    "nu": {
+      "flags": "",
+      "unsupported": "",
+      "git": "https://github.com/nushell/nushell",
+      "bins": [
+        "nu"
+      ]
+    },
+
+    "gitoxide": {
+      "flags": "--no-default-features --features max-pure",
+      "unsupported": "",
+      "git": "https://github.com/Byron/gitoxide",
+      "bins": [
+        "ein",
+        "gix"
+      ]
+    },
+
+    "exa": {
+      "flags": "",
+      "unsupported": "",
+      "git": "https://github.com/ogham/exa",
+      "bins": [
+        "exa"
+      ]
+    },
+
+    "du-dust": {
+      "flags": "",
+      "unsupported": "",
+      "git": "https://github.com/bootandy/dust",
+      "bins": [
+        "dust"
+      ]
+    },
+
+    "bat": {
+      "flags": "",
+      "unsupported": "",
+      "git": "https://github.com/sharkdp/bat",
+      "bins": [
+        "bat"
+      ]
     }
   },
-  "allowlist": "cross"
+  "allowlist": "nu,gitoxide,exa,du-dust,bat"
 }

--- a/crates.json
+++ b/crates.json
@@ -341,15 +341,6 @@
       ]
     },
 
-    "nu": {
-      "flags": "--features static-link-openssl",
-      "unsupported": "",
-      "git": "https://github.com/nushell/nushell",
-      "bins": [
-        "nu"
-      ]
-    },
-
     "gitoxide": {
       "flags": "--no-default-features --features max-pure",
       "unsupported": "x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
@@ -405,5 +396,5 @@
       ]
     }
   },
-  "allowlist": "nu,gitoxide,du-dust,bat"
+  "allowlist": "zellij,mprocs,ripgrep"
 }

--- a/crates.json
+++ b/crates.json
@@ -369,24 +369,6 @@
       ]
     },
 
-    "zellij": {
-      "flags": "",
-      "unsupported": "",
-      "git": "https://github.com/zellij-org/zellij",
-      "bins": [
-        "zellij"
-      ]
-    },
-
-    "mprocs": {
-      "flags": "",
-      "unsupported": "",
-      "git": "https://github.com/pvolok/mprocs",
-      "bins": [
-        "mprocs"
-      ]
-    },
-
     "ripgrep": {
       "flags": "",
       "unsupported": "",
@@ -396,5 +378,5 @@
       ]
     }
   },
-  "allowlist": "zellij,mprocs,ripgrep"
+  "allowlist": ""
 }

--- a/crates.json
+++ b/crates.json
@@ -378,5 +378,5 @@
       ]
     }
   },
-  "allowlist": ""
+  "allowlist": "bat"
 }

--- a/crates.json
+++ b/crates.json
@@ -342,7 +342,7 @@
     },
 
     "nu": {
-      "flags": "",
+      "flags": "--features static-link-openssl",
       "unsupported": "",
       "git": "https://github.com/nushell/nushell",
       "bins": [
@@ -352,7 +352,7 @@
 
     "gitoxide": {
       "flags": "--no-default-features --features max-pure",
-      "unsupported": "",
+      "unsupported": "x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
       "git": "https://github.com/Byron/gitoxide",
       "bins": [
         "ein",
@@ -360,18 +360,9 @@
       ]
     },
 
-    "exa": {
-      "flags": "",
-      "unsupported": "",
-      "git": "https://github.com/ogham/exa",
-      "bins": [
-        "exa"
-      ]
-    },
-
     "du-dust": {
       "flags": "",
-      "unsupported": "",
+      "unsupported": "powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
       "git": "https://github.com/bootandy/dust",
       "bins": [
         "dust"
@@ -380,12 +371,39 @@
 
     "bat": {
       "flags": "",
-      "unsupported": "",
+      "unsupported": "x86_64-unknown-netbsd,x86_64-sun-solaris,i686-unknown-freebsd",
       "git": "https://github.com/sharkdp/bat",
       "bins": [
         "bat"
       ]
+    },
+
+    "zellij": {
+      "flags": "",
+      "unsupported": "",
+      "git": "https://github.com/zellij-org/zellij",
+      "bins": [
+        "zellij"
+      ]
+    },
+
+    "mprocs": {
+      "flags": "",
+      "unsupported": "",
+      "git": "https://github.com/pvolok/mprocs",
+      "bins": [
+        "mprocs"
+      ]
+    },
+
+    "ripgrep": {
+      "flags": "",
+      "unsupported": "",
+      "git": "https://github.com/BurntSushi/ripgrep",
+      "bins": [
+        "rg"
+      ]
     }
   },
-  "allowlist": "nu,gitoxide,exa,du-dust,bat"
+  "allowlist": "nu,gitoxide,du-dust,bat"
 }

--- a/upcoming.json
+++ b/upcoming.json
@@ -26,6 +26,15 @@
       "bins": [
         ""
       ]
+    },
+
+    "nu": {
+      "flags": "--features static-link-openssl",
+      "unsupported": "",
+      "git": "https://github.com/nushell/nushell",
+      "bins": [
+        "nu"
+      ]
     }
   }
 }

--- a/upcoming.json
+++ b/upcoming.json
@@ -1,5 +1,14 @@
 {
   "crates": {
+    "": {
+      "flags": "",
+      "unsupported": "",
+      "git": "",
+      "bins": [
+        ""
+      ]
+    },
+
     "cargo-wasi": {
       "_comment": "Does not currently allow for vendored or rustls.",
       "flags": "",
@@ -7,6 +16,15 @@
       "github": "https://github.com/bytecodealliance/cargo-wasi",
       "bins": [
         "cargo-wasi"
+      ]
+    },
+
+    "coreutils": {
+      "flags": "",
+      "unsupported": "",
+      "git": "https://crates.io/crates/coreutils",
+      "bins": [
+        ""
       ]
     }
   }


### PR DESCRIPTION
- [x] Add to README

Can build:
- [x] ~nu~ (Overrides toolchain, See #54)
- [x] gitoxide
- [x] ~exa~ (Does not compile on windows)
- [x] du-dust
- [x] bat
- [x] ~zellij~ (Does not compile on windows)
- [x] ~mprocs~ (No Lua bindings for many platforms)
- [x] ripgrep