### PR TITLE
Allow for audit reports and use auditable for non-cross builds

### DIFF
--- a/crates.json
+++ b/crates.json
@@ -449,5 +449,5 @@
       ]
     }
   },
-  "allowlist": "just,cargo-info,cargo-prebuilt"
+  "allowlist": "cargo-prebuilt"
 }

--- a/crates.json
+++ b/crates.json
@@ -449,5 +449,5 @@
       ]
     }
   },
-  "allowlist": "just,cargo-info"
+  "allowlist": "just,cargo-info,cargo-prebuilt"
 }

--- a/crates.json
+++ b/crates.json
@@ -449,5 +449,5 @@
       ]
     }
   },
-  "allowlist": "just,cargo-info,cargo-prebuilt,speedtest-rs,cargo-build-deps"
+  "allowlist": "just,cargo-info,cargo-prebuilt"
 }

--- a/crates.json
+++ b/crates.json
@@ -449,5 +449,5 @@
       ]
     }
   },
-  "allowlist": "crate"
+  "allowlist": "just,cargo-info"
 }

--- a/crates.json
+++ b/crates.json
@@ -449,5 +449,5 @@
       ]
     }
   },
-  "allowlist": "just,cargo-info,cargo-prebuilt"
+  "allowlist": "just,cargo-info,cargo-prebuilt,speedtest-rs,cargo-build-deps"
 }

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -48,9 +48,11 @@ jobs:
       - name: Generate reports
         working-directory: ./bundle/build
         run: |
+          echo "Generated on: $(date)" > ../../deps.report
+          echo "Generated on: $(date)" > ../../audit.report
           test -f Cargo.lock || cargo +stable generate-lockfile --verbose
-          cargo +stable tree --verbose -e no-dev > ../../deps.report
-          cargo audit > ../../audit.report || true
+          cargo +stable tree --verbose -e no-dev >> ../../deps.report
+          cargo audit >> ../../audit.report || true
       - name: Bundle Deps
         run: |
           mkdir -p ./bundle/store/registry

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install cargo-prebuilt
         uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
-        run: cargo prebuilt cargo-audit,cargo-auditable
+        run: cargo prebuilt cargo-audit,cargo-auditable,cross
+      - run: cross --version
 
   setup:
     runs-on: ubuntu-latest

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -55,6 +55,7 @@ jobs:
         working-directory: ./bundle/build
         run: cargo +stable fetch --verbose
       - name: "TODO: Audit"
+        working-directory: ./bundle/build
         run: |
           cargo +stable tree --verbose -e no-dev
           cargo +stable generate-lockfile --verbose

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -54,6 +54,10 @@ jobs:
       - name: Download Deps
         working-directory: ./bundle/build
         run: cargo +stable fetch --verbose
+      - name: "TODO: Audit"
+        run: |
+          cargo +stable tree --verbose -e no-dev
+          cargo +stable generate-lockfile --verbose
       - name: Bundle Deps
         run: |
           mkdir -p ./bundle/store/registry

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -44,12 +44,12 @@ jobs:
           mv ${{ env.crate }}-${{ env.version }}/* bundle/build
       - name: Download Deps
         working-directory: ./bundle/build
-        run: cargo +stable fetch --verbose --locked
+        run: cargo +stable fetch --verbose
       - name: Generate reports
         working-directory: ./bundle/build
         run: |
           test -f Cargo.lock || cargo +stable generate-lockfile --verbose
-          echo "Generated on: $(date --utc)" > ../../deps.report && cargo +stable tree --verbose --locked -e no-dev >> ../../deps.report
+          echo "Generated on: $(date --utc)" > ../../deps.report && cargo +stable tree --verbose -e no-dev >> ../../deps.report
           echo "Generated on: $(date --utc)" > ../../audit.report && cargo audit >> ../../audit.report || true
       - name: Bundle Deps
         run: |
@@ -106,7 +106,7 @@ jobs:
           cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable auditable build --verbose --release --locked %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py x86_64-unknown-linux-gnu ./build/target/release ${{ env.bins }}
       - name: Artifact
@@ -155,7 +155,7 @@ jobs:
           cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable auditable build --verbose --release --locked %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py x86_64-apple-darwin ./build/target/release ${{ env.bins }}
       - name: Artifact
@@ -206,7 +206,7 @@ jobs:
           cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable auditable build --verbose --release --locked --target aarch64-apple-darwin %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release --target aarch64-apple-darwin %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py aarch64-apple-darwin ./build/target/aarch64-apple-darwin/release ${{ env.bins }}
       - name: Artifact
@@ -253,7 +253,7 @@ jobs:
           cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable auditable build --verbose --release --locked %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release %%FLAGS%%
       - name: Collect
         run: python3  ./scripts/collect.py x86_64-pc-windows-msvc ./build/target/release ${{ env.bins }}
       - name: Artifact
@@ -303,7 +303,7 @@ jobs:
           cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable auditable build --verbose --release --locked --target i686-pc-windows-msvc %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release --target i686-pc-windows-msvc %%FLAGS%%
       - name: Collect
         run: python3  ./scripts/collect.py i686-pc-windows-msvc ./build/target/i686-pc-windows-msvc/release ${{ env.bins }}
       - name: Artifact
@@ -357,7 +357,7 @@ jobs:
           cross --version
       - name: Build crate
         working-directory: ./build
-        run: cross +stable build --verbose --release --locked --target ${{ matrix.target }} %%FLAGS%%
+        run: cross +stable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py ${{ matrix.target }} ./build/target/${{ matrix.target }}/release ${{ env.bins }}
       - name: Artifact
@@ -411,7 +411,7 @@ jobs:
           cross --version
       - name: Build crate
         working-directory: ./build
-        run: cross +stable build --verbose --release --locked --target ${{ matrix.target }} %%FLAGS%%
+        run: cross +stable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py ${{ matrix.target }} ./build/target/${{ matrix.target }}/release ${{ env.bins }}
       - name: Artifact

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -337,11 +337,11 @@ jobs:
       - uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
         run: |
-          cargo prebuilt cross
+          cargo prebuilt cross,cargo-auditable
           cross --version
       - name: Build crate
         working-directory: ./build
-        run: cross +stable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
+        run: cross +stable auditable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py ${{ matrix.target }} ./build/target/${{ matrix.target }}/release ${{ env.bins }}
       - name: Artifact

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -15,6 +15,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  test-job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install cargo-prebuilt
+        uses: crow-rest/cargo-prebuilt-action@v1
+      - name: Install tools
+        run: cargo prebuilt cargo-audit cargo-auditable
+
   setup:
     runs-on: ubuntu-latest
     steps:

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -57,8 +57,8 @@ jobs:
       - name: "TODO: Audit"
         working-directory: ./bundle/build
         run: |
+          test -f Cargo.lock || cargo +stable generate-lockfile --verbose
           cargo +stable tree --verbose -e no-dev
-          cargo +stable generate-lockfile --verbose
       - name: Bundle Deps
         run: |
           mkdir -p ./bundle/store/registry

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -127,7 +127,7 @@ jobs:
           file: x86_64-unknown-linux-gnu.*
 
   x86_64-apple-darwin:
-    runs-on: macos-12
+    runs-on: macos-latest
     needs: [ setup ]
     steps:
       - uses: actions/checkout@v3
@@ -173,7 +173,7 @@ jobs:
           file: x86_64-apple-darwin.*
 
   aarch64-apple-darwin:
-    runs-on: macos-12
+    runs-on: macos-latest
     needs: [ setup ]
     steps:
       - uses: actions/checkout@v3

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Generate reports
         working-directory: ./bundle/build
         run: |
-          echo "Generated on: $(date)" > ../../deps.report
-          echo "Generated on: $(date)" > ../../audit.report
+          echo "Generated on: $(date --utc)" > ../../deps.report
+          echo "Generated on: $(date --utc)" > ../../audit.report
           test -f Cargo.lock || cargo +stable generate-lockfile --verbose
           cargo +stable tree --verbose -e no-dev >> ../../deps.report
           cargo audit >> ../../audit.report || true

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install cargo-prebuilt
         uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
-        run: cargo prebuilt cargo-audit cargo-auditable
+        run: cargo prebuilt cargo-audit,cargo-auditable
 
   setup:
     runs-on: ubuntu-latest

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -143,8 +143,6 @@ jobs:
           path: |
            build/target
           key: ${{ runner.os }}-${{ env.crate }}-${{ env.version }}-stable-x86_64-apple-darwin
-      - name: Get pkgs
-        run: brew install coreutils
       - name: Update Rust
         run: rustup update
       - name: Rust Version
@@ -192,8 +190,6 @@ jobs:
           path: |
            build/target
           key: ${{ runner.os }}-${{ env.crate }}-${{ env.version }}-stable-aarch64-apple-darwin
-      - name: Get pkgs
-        run: brew install coreutils
       - name: Update Rust
         run: rustup update
       - name: Rust Version

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -48,11 +48,9 @@ jobs:
       - name: Generate reports
         working-directory: ./bundle/build
         run: |
-          echo "Generated on: $(date --utc)" > ../../deps.report
-          echo "Generated on: $(date --utc)" > ../../audit.report
           test -f Cargo.lock || cargo +stable generate-lockfile --verbose
-          cargo +stable tree --verbose -e no-dev >> ../../deps.report
-          cargo audit >> ../../audit.report || true
+          echo "Generated on: $(date --utc)" > ../../deps.report && cargo +stable tree --verbose -e no-dev >> ../../deps.report
+          echo "Generated on: $(date --utc)" > ../../audit.report && cargo audit >> ../../audit.report || true
       - name: Bundle Deps
         run: |
           mkdir -p ./bundle/store/registry

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -58,7 +58,8 @@ jobs:
         working-directory: ./bundle/build
         run: |
           test -f Cargo.lock || cargo +stable generate-lockfile --verbose
-          cargo +stable tree --verbose -e no-dev
+          cargo +stable tree --verbose -e no-dev > ../../deps.report
+          cargo audit > ../../audit.report || true
       - name: Bundle Deps
         run: |
           mkdir -p ./bundle/store/registry
@@ -72,6 +73,21 @@ jobs:
           name: crate
           path: bundle
           retention-days: 1
+      - name: Store reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: reports
+          path: "*.report"
+      - name: Release Artifact
+        if: %%IF%%
+        uses: svenstaro/upload-release-action@2.5.0
+        with:
+          tag: ${{ env.crate }}-${{ env.version }}
+          release_name: ${{ env.crate }}-${{ env.version }}
+          overwrite: true
+          prerelease: true
+          file_glob: true
+          file: "*.report"
 
   x86_64-unknown-linux-gnu:
     runs-on: ubuntu-latest

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -391,11 +391,11 @@ jobs:
       - uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
         run: |
-          cargo prebuilt cross
+          cargo prebuilt cross,cargo-auditable
           cross --version
       - name: Build crate
         working-directory: ./build
-        run: cross +stable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
+        run: cross +stable auditable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py ${{ matrix.target }} ./build/target/${{ matrix.target }}/release ${{ env.bins }}
       - name: Artifact

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -100,9 +100,13 @@ jobs:
         run: rustup update
       - name: Rust Version
         run: rustc --version
+      - uses: crow-rest/cargo-prebuilt-action@v1
+      - name: Install tools
+        run: |
+          cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable build --verbose --release %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py x86_64-unknown-linux-gnu ./build/target/release ${{ env.bins }}
       - name: Artifact

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -149,9 +149,13 @@ jobs:
         run: rustup update
       - name: Rust Version
         run: rustc --version
+      - uses: crow-rest/cargo-prebuilt-action@v1
+      - name: Install tools
+        run: |
+          cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable build --verbose --release %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py x86_64-apple-darwin ./build/target/release ${{ env.bins }}
       - name: Artifact
@@ -196,9 +200,13 @@ jobs:
         run: rustc --version
       - name: Add Rust target
         run: rustup target add aarch64-apple-darwin
+      - uses: crow-rest/cargo-prebuilt-action@v1
+      - name: Install tools
+        run: |
+          cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable build --verbose --release --target aarch64-apple-darwin %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release --target aarch64-apple-darwin %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py aarch64-apple-darwin ./build/target/aarch64-apple-darwin/release ${{ env.bins }}
       - name: Artifact
@@ -239,9 +247,13 @@ jobs:
         run: rustup update
       - name: Rust Version
         run: rustc --version
+      - uses: crow-rest/cargo-prebuilt-action@v1
+      - name: Install tools
+        run: |
+          cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable build --verbose --release %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release %%FLAGS%%
       - name: Collect
         run: python3  ./scripts/collect.py x86_64-pc-windows-msvc ./build/target/release ${{ env.bins }}
       - name: Artifact
@@ -285,9 +297,13 @@ jobs:
         run: rustc --version
       - name: Add Rust target
         run: rustup target add i686-pc-windows-msvc
+      - uses: crow-rest/cargo-prebuilt-action@v1
+      - name: Install tools
+        run: |
+          cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable build --verbose --release --target i686-pc-windows-msvc %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release --target i686-pc-windows-msvc %%FLAGS%%
       - name: Collect
         run: python3  ./scripts/collect.py i686-pc-windows-msvc ./build/target/i686-pc-windows-msvc/release ${{ env.bins }}
       - name: Artifact
@@ -337,11 +353,11 @@ jobs:
       - uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
         run: |
-          cargo prebuilt cross,cargo-auditable
+          cargo prebuilt cross
           cross --version
       - name: Build crate
         working-directory: ./build
-        run: cross +stable auditable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
+        run: cross +stable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py ${{ matrix.target }} ./build/target/${{ matrix.target }}/release ${{ env.bins }}
       - name: Artifact
@@ -391,11 +407,11 @@ jobs:
       - uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
         run: |
-          cargo prebuilt cross,cargo-auditable
+          cargo prebuilt cross
           cross --version
       - name: Build crate
         working-directory: ./build
-        run: cross +stable auditable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
+        run: cross +stable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py ${{ matrix.target }} ./build/target/${{ matrix.target }}/release ${{ env.bins }}
       - name: Artifact

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -44,12 +44,12 @@ jobs:
           mv ${{ env.crate }}-${{ env.version }}/* bundle/build
       - name: Download Deps
         working-directory: ./bundle/build
-        run: cargo +stable fetch --verbose
+        run: cargo +stable fetch --verbose --locked
       - name: Generate reports
         working-directory: ./bundle/build
         run: |
           test -f Cargo.lock || cargo +stable generate-lockfile --verbose
-          echo "Generated on: $(date --utc)" > ../../deps.report && cargo +stable tree --verbose -e no-dev >> ../../deps.report
+          echo "Generated on: $(date --utc)" > ../../deps.report && cargo +stable tree --verbose --locked -e no-dev >> ../../deps.report
           echo "Generated on: $(date --utc)" > ../../audit.report && cargo audit >> ../../audit.report || true
       - name: Bundle Deps
         run: |
@@ -106,7 +106,7 @@ jobs:
           cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable auditable build --verbose --release %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release --locked %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py x86_64-unknown-linux-gnu ./build/target/release ${{ env.bins }}
       - name: Artifact
@@ -155,7 +155,7 @@ jobs:
           cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable auditable build --verbose --release %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release --locked %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py x86_64-apple-darwin ./build/target/release ${{ env.bins }}
       - name: Artifact
@@ -206,7 +206,7 @@ jobs:
           cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable auditable build --verbose --release --target aarch64-apple-darwin %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release --locked --target aarch64-apple-darwin %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py aarch64-apple-darwin ./build/target/aarch64-apple-darwin/release ${{ env.bins }}
       - name: Artifact
@@ -253,7 +253,7 @@ jobs:
           cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable auditable build --verbose --release %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release --locked %%FLAGS%%
       - name: Collect
         run: python3  ./scripts/collect.py x86_64-pc-windows-msvc ./build/target/release ${{ env.bins }}
       - name: Artifact
@@ -303,7 +303,7 @@ jobs:
           cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
-        run: cargo +stable auditable build --verbose --release --target i686-pc-windows-msvc %%FLAGS%%
+        run: cargo +stable auditable build --verbose --release --locked --target i686-pc-windows-msvc %%FLAGS%%
       - name: Collect
         run: python3  ./scripts/collect.py i686-pc-windows-msvc ./build/target/i686-pc-windows-msvc/release ${{ env.bins }}
       - name: Artifact
@@ -357,7 +357,7 @@ jobs:
           cross --version
       - name: Build crate
         working-directory: ./build
-        run: cross +stable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
+        run: cross +stable build --verbose --release --locked --target ${{ matrix.target }} %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py ${{ matrix.target }} ./build/target/${{ matrix.target }}/release ${{ env.bins }}
       - name: Artifact
@@ -411,7 +411,7 @@ jobs:
           cross --version
       - name: Build crate
         working-directory: ./build
-        run: cross +stable build --verbose --release --target ${{ matrix.target }} %%FLAGS%%
+        run: cross +stable build --verbose --release --locked --target ${{ matrix.target }} %%FLAGS%%
       - name: Collect
         run: ./scripts/collect.py ${{ matrix.target }} ./build/target/${{ matrix.target }}/release ${{ env.bins }}
       - name: Artifact

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -102,8 +102,7 @@ jobs:
         run: rustc --version
       - uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
-        run: |
-          cargo prebuilt cargo-auditable
+        run: cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
         run: cargo +stable auditable build --verbose --release %%FLAGS%%
@@ -149,8 +148,7 @@ jobs:
         run: rustc --version
       - uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
-        run: |
-          cargo prebuilt cargo-auditable
+        run: cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
         run: cargo +stable auditable build --verbose --release %%FLAGS%%
@@ -198,8 +196,7 @@ jobs:
         run: rustup target add aarch64-apple-darwin
       - uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
-        run: |
-          cargo prebuilt cargo-auditable
+        run: cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
         run: cargo +stable auditable build --verbose --release --target aarch64-apple-darwin %%FLAGS%%
@@ -245,8 +242,7 @@ jobs:
         run: rustc --version
       - uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
-        run: |
-          cargo prebuilt cargo-auditable
+        run: cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
         run: cargo +stable auditable build --verbose --release %%FLAGS%%
@@ -295,8 +291,7 @@ jobs:
         run: rustup target add i686-pc-windows-msvc
       - uses: crow-rest/cargo-prebuilt-action@v1
       - name: Install tools
-        run: |
-          cargo prebuilt cargo-auditable
+        run: cargo prebuilt cargo-auditable
       - name: Build crate
         working-directory: ./build
         run: cargo +stable auditable build --verbose --release --target i686-pc-windows-msvc %%FLAGS%%

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -15,16 +15,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test-job:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install cargo-prebuilt
-        uses: crow-rest/cargo-prebuilt-action@v1
-      - name: Install tools
-        run: cargo prebuilt cargo-audit,cargo-auditable,cross
-      - run: cross --version
-
   setup:
     runs-on: ubuntu-latest
     steps:
@@ -55,7 +45,7 @@ jobs:
       - name: Download Deps
         working-directory: ./bundle/build
         run: cargo +stable fetch --verbose
-      - name: "TODO: Audit"
+      - name: Generate reports
         working-directory: ./bundle/build
         run: |
           test -f Cargo.lock || cargo +stable generate-lockfile --verbose
@@ -79,7 +69,7 @@ jobs:
         with:
           name: reports
           path: "*.report"
-      - name: Release Artifact
+      - name: Release Reports
         if: %%IF%%
         uses: svenstaro/upload-release-action@2.5.0
         with:
@@ -124,7 +114,7 @@ jobs:
             x86_64-unknown-linux-gnu.sha256
       - name: Release Artifact
         if: %%IF%%
-        uses: svenstaro/upload-release-action@2.4.0
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           tag: ${{ env.crate }}-${{ env.version }}
           release_name: ${{ env.crate }}-${{ env.version }}
@@ -169,7 +159,7 @@ jobs:
             x86_64-apple-darwin.sha256
       - name: Release Artifact
         if: %%IF%%
-        uses: svenstaro/upload-release-action@2.4.0
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           tag: ${{ env.crate }}-${{ env.version }}
           release_name: ${{ env.crate }}-${{ env.version }}
@@ -216,7 +206,7 @@ jobs:
             aarch64-apple-darwin.sha256
       - name: Release Artifact
         if: %%IF%%
-        uses: svenstaro/upload-release-action@2.4.0
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           tag: ${{ env.crate }}-${{ env.version }}
           release_name: ${{ env.crate }}-${{ env.version }}
@@ -259,7 +249,7 @@ jobs:
             x86_64-pc-windows-msvc.sha256
       - name: Release Artifact
         if: %%IF%%
-        uses: svenstaro/upload-release-action@2.4.0
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           tag: ${{ env.crate }}-${{ env.version }}
           release_name: ${{ env.crate }}-${{ env.version }}
@@ -305,7 +295,7 @@ jobs:
             i686-pc-windows-msvc.sha256
       - name: Release Artifact
         if: %%IF%%
-        uses: svenstaro/upload-release-action@2.4.0
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           tag: ${{ env.crate }}-${{ env.version }}
           release_name: ${{ env.crate }}-${{ env.version }}
@@ -359,7 +349,7 @@ jobs:
             ${{ matrix.target }}.sha256
       - name: Release Artifact
         if: %%IF%%
-        uses: svenstaro/upload-release-action@2.4.0
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           tag: ${{ env.crate }}-${{ env.version }}
           release_name: ${{ env.crate }}-${{ env.version }}
@@ -413,7 +403,7 @@ jobs:
             ${{ matrix.target }}.sha256
       - name: Release Artifact
         if: %%IF%%
-        uses: svenstaro/upload-release-action@2.4.0
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           tag: ${{ env.crate }}-${{ env.version }}
           release_name: ${{ env.crate }}-${{ env.version }}
@@ -431,7 +421,7 @@ jobs:
       - name: Create index file
         run: echo "${{ env.version }}" > ${{ env.crate }}
       - name: Push to index
-        uses: svenstaro/upload-release-action@2.4.0
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           tag: stable-index
           overwrite: true


### PR DESCRIPTION
Closes #62

This pull request adds a few things:
- Uses cargo-auditable for non-cross built crates
- Generates a report of deps used using cargo tree
- Generates a report of security issues found (At time of build) using cargo-audit